### PR TITLE
Updating to use only Notion source

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -12,6 +12,7 @@ useSeoMeta({
     <Html lang="en" />
     <NuxtLoadingIndicator />
     <AppNavbar />
+    <NotionNavbar />
     <NuxtPage />
   </div>
 </template>

--- a/app/app.vue
+++ b/app/app.vue
@@ -11,7 +11,6 @@ useSeoMeta({
   <div class="sm:pt-6 sm:pb-10">
     <Html lang="en" />
     <NuxtLoadingIndicator />
-    <AppNavbar />
     <NotionNavbar />
     <NuxtPage />
   </div>

--- a/app/components/NotionNavbar.vue
+++ b/app/components/NotionNavbar.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+const { data: notionNavigation } = await useAsyncData('notion-navigation', () => {
+  return queryCollection('notion')
+    .where('section', '=', 'Nav')
+    .all()
+})
+</script>
+
+<template>
+  <div class="flex justify-between px-4 py-4 mx-auto sm:px-8 max-w-4xl">
+    <!-- Navigation -->
+    <div class="text-gray-700 dark:text-gray-200">
+      <NuxtLink
+        v-for="item in notionNavigation"
+        :key="item.id"
+        :to="`/${item.id.replace(/^notion\/|\.md$/g, '')}`"
+        class="mr-6"
+        active-class="font-bold"
+      >
+        {{ item.title }}
+      </NuxtLink>
+    </div>
+  </div>
+</template> 

--- a/app/components/NotionNavbar.vue
+++ b/app/components/NotionNavbar.vue
@@ -2,6 +2,7 @@
 const { data: notionNavigation } = await useAsyncData('notion-navigation', () => {
   return queryCollection('notion')
     .where('section', '=', 'Nav')
+    .order('postedDate', 'ASC')
     .all()
 })
 </script>

--- a/app/components/NotionNavbar.vue
+++ b/app/components/NotionNavbar.vue
@@ -2,6 +2,7 @@
 const { data: notionNavigation } = await useAsyncData('notion-navigation', () => {
   return queryCollection('notion')
     .where('section', '=', 'Nav')
+    .select('pageSlug', 'title', 'notionId', 'postedDate')
     .order('postedDate', 'ASC')
     .all()
 })
@@ -13,8 +14,8 @@ const { data: notionNavigation } = await useAsyncData('notion-navigation', () =>
     <div class="text-gray-700 dark:text-gray-200">
       <NuxtLink
         v-for="item in notionNavigation"
-        :key="item.id"
-        :to="`/${item.id.replace(/^notion\/|\.md$/g, '')}`"
+        :key="item.notionId"
+        :to="`/${item.pageSlug}`"
         class="mr-6"
         active-class="font-bold"
       >

--- a/app/components/NotionPosts.vue
+++ b/app/components/NotionPosts.vue
@@ -2,10 +2,13 @@
 const { data: posts } = await useAsyncData('notion-posts', () => {
   return queryCollection('notion')
     .where('section', '=', 'Writing')
-    .select('id', 'title', 'description', 'postedDate', 'url')
+    .select('pageSlug', 'title', 'description', 'postedDate', 'url', 'notionId')
     .order('postedDate', 'DESC')
     .all();
 });
+
+// Debug log to help diagnose issues
+console.log('Posts data:', posts.value);
 </script>
 
 <template>
@@ -21,10 +24,10 @@ const { data: posts } = await useAsyncData('notion-posts', () => {
     <div v-else class="space-y-1">
       <article 
         v-for="post in posts" 
-        :key="post.id" 
+        :key="post.notionId" 
         class="post-card group border-b border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 transition-colors duration-200"
       >
-        <NuxtLink :to="`/writing/${post.id.replace(/^notion\/|\.md$/g, '')}`" class="block px-3 no-underline -mt-2">
+        <NuxtLink :to="`/${post.pageSlug}`" class="block px-3 no-underline -mt-2">
           <h2 class="text-xl font-medium text-gray-800 dark:text-gray-200 group-hover:text-blue-500">
             {{ post.title }}
           </h2>

--- a/app/components/NotionPosts.vue
+++ b/app/components/NotionPosts.vue
@@ -1,6 +1,7 @@
 <script setup>
 const { data: posts } = await useAsyncData('notion-posts', () => {
   return queryCollection('notion')
+    .where('section', '=', 'Writing')
     .select('id', 'title', 'description', 'postedDate', 'url')
     .order('postedDate', 'DESC')
     .all();
@@ -20,7 +21,7 @@ const { data: posts } = await useAsyncData('notion-posts', () => {
     <div v-else class="space-y-1">
       <article 
         v-for="post in posts" 
-        :key="post._id" 
+        :key="post.id" 
         class="post-card group border-b border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 transition-colors duration-200"
       >
         <NuxtLink :to="`/writing/${post.id.replace(/^notion\/|\.md$/g, '')}`" class="block px-3 no-underline -mt-2">

--- a/app/pages/[...slug].vue
+++ b/app/pages/[...slug].vue
@@ -15,8 +15,13 @@ const { data: page } = await useAsyncData(`notion-${route.params.slug}`, () => {
       .first()
   }
   
+  // Join slug parts to match pageSlug format
+  const slug = Array.isArray(route.params.slug) 
+    ? route.params.slug.join('/')
+    : route.params.slug
+
   return queryCollection('notion')
-    .where('id', '=', `notion/${route.params.slug}.md`)
+    .where('pageSlug', '=', slug)
     .first()
 })
 

--- a/app/pages/[...slug].vue
+++ b/app/pages/[...slug].vue
@@ -7,6 +7,14 @@ import type { LayoutKey } from '#build/types/layouts'
 const route = useRoute()
 
 const { data: page } = await useAsyncData(`notion-${route.params.slug}`, () => {
+  // Handle root page
+  if (!route.params.slug || route.params.slug.length === 0) {
+    return queryCollection('notion')
+      .where('section', '=', 'Nav')
+      .order('postedDate', 'ASC')
+      .first()
+  }
+  
   return queryCollection('notion')
     .where('id', '=', `notion/${route.params.slug}.md`)
     .first()

--- a/app/pages/[...slug].vue
+++ b/app/pages/[...slug].vue
@@ -1,27 +1,16 @@
 <script setup lang="ts">
 /**
- * Document driven is removed in Content v3.
- * This page is a simple/full-feature replacement of document driven.
+ * Simple page component that renders notion pages based on their layout
  */
 import type { LayoutKey } from '#build/types/layouts'
 
 const route = useRoute()
 
-// First try to get from content collection
-const { data: contentPage } = await useAsyncData(`content-${route.params.slug}`, () => {
-  return queryCollection('content').path(route.path).first()
-})
-
-// If not found in content, try notion collection
-const { data: notionPage } = await useAsyncData(`notion-${route.params.slug}`, async () => {
-  if (contentPage.value) return null
+const { data: page } = await useAsyncData(`notion-${route.params.slug}`, () => {
   return queryCollection('notion')
     .where('id', '=', `notion/${route.params.slug}.md`)
     .first()
 })
-
-// Use either content or notion page
-const page = computed(() => contentPage.value || notionPage.value)
 
 // Get layout from page or default
 const layout = computed<LayoutKey>(() => 
@@ -35,7 +24,10 @@ if (!page.value) {
   })
 }
 
-useSeoMeta(page.value?.seo || {})
+useSeoMeta({
+  title: page.value.title,
+  description: page.value.description
+})
 </script>
 
 <template>

--- a/app/pages/writing/[id].vue
+++ b/app/pages/writing/[id].vue
@@ -9,9 +9,8 @@ definePageMeta({
 const { data: post } = await useAsyncData(`post-${route.params.id}`, async () => {
   console.log("Route", route.params.id)
   return queryCollection('notion')
-    .where('id', '=', `notion/${route.params.id}.md`)
+    .where('pageSlug', '=', `writing/${route.params.id}`)
     .first()
-    
 })
 
 if (!post.value) {

--- a/content.config.ts
+++ b/content.config.ts
@@ -17,6 +17,7 @@ if (NOTION_TOKEN && NOTION_DATABASE_ID) {
   console.warn('⚠️ Notion source disabled: Missing environment variables NOTION_TOKEN and/or NOTION_DATABASE_ID')
 }
 
+
 const notionSource = defineCollectionSource({
   getKeys: async () => {
     if (!notion || !NOTION_DATABASE_ID) return []
@@ -85,7 +86,7 @@ layout: ${layout}
 
       // Return complete markdown file with frontmatter
       const content = frontmatter + (markdownContent || '').trim();
-      console.log('✅ Processed page data:', title)
+      console.log(`✅ Processed page data: [${section}][layout: ${layout}]: ${title}`)
 
       return content
     } catch (error) {
@@ -101,6 +102,7 @@ const notionCollection = defineCollection({
   source: notionSource,
   // Schema for the frontmatter
   schema: z.object({
+    index: z.number(),
     title: z.string(),
     description: z.string(),
     postedDate: z.string(),
@@ -113,13 +115,20 @@ const notionCollection = defineCollection({
 
 export default defineContentConfig({
   collections: {
+    // Keep content collection for future use but not actively used
     content: defineCollection({
       type: 'page',
       source: '**',
       schema: z.object({
-        layout: z.string()
+        title: z.string().optional(),
+        description: z.string().optional(),
+        layout: z.string().optional(),
+        navigation: z.object({
+          title: z.string()
+        }).optional()
       })
     }),
+    // Primary content source
     notion: notionCollection
   }
 })

--- a/content.config.ts
+++ b/content.config.ts
@@ -65,6 +65,10 @@ const notionSource = defineCollectionSource({
       const section = properties.Section?.type === 'select'
         ? properties.Section.select?.name || ''
         : ''
+      // Extract layout with default value
+      const layout = properties.Layout?.type === 'select'
+        ? properties.Layout.select?.name || 'default'
+        : 'default'
 
       // Format as a markdown file with frontmatter
       const frontmatter = `---
@@ -74,6 +78,7 @@ postedDate: ${postedDate}
 url: ${pageData.url}
 id: ${pageData.id}
 section: ${section}
+layout: ${layout}
 ---
 
 `;
@@ -101,7 +106,8 @@ const notionCollection = defineCollection({
     postedDate: z.string(),
     url: z.string(),
     id: z.string(),
-    section: z.string()
+    section: z.string(),
+    layout: z.enum(['default', 'full-width', 'posts']).default('default')
   })
 })
 

--- a/content.config.ts
+++ b/content.config.ts
@@ -62,6 +62,9 @@ const notionSource = defineCollectionSource({
       const postedDate = properties.Date?.type === 'date'
         ? properties.Date.date?.start || ''
         : ''
+      const section = properties.Section?.type === 'select'
+        ? properties.Section.select?.name || ''
+        : ''
 
       // Format as a markdown file with frontmatter
       const frontmatter = `---
@@ -70,6 +73,7 @@ description: ${description}
 postedDate: ${postedDate}
 url: ${pageData.url}
 id: ${pageData.id}
+section: ${section}
 ---
 
 `;
@@ -96,7 +100,8 @@ const notionCollection = defineCollection({
     description: z.string(),
     postedDate: z.string(),
     url: z.string(),
-    id: z.string()
+    id: z.string(),
+    section: z.string()
   })
 })
 


### PR DESCRIPTION
Updating to exclusively use the Notion source - regular markdown dependent `content` collection still exists, but remains unused

### Changes by Component

#### content.config.ts
- Added new frontmatter field `pageSlug` for URL-friendly paths
- Modified `getItem` to generate semantic URLs:
  ```typescript
  // Generate URL-friendly title
  const urlTitle = title.toLowerCase().replace(/[^a-z0-9]+/g, '-')
  
  // Format date for non-Nav sections
  const dateStr = section !== 'Nav' && postedDate
    ? `-${new Date(postedDate).toISOString().split('T')[0]}`
    : ''
    
  // Generate pageSlug based on section
  const pageSlug = section === 'Nav'
    ? urlTitle
    : `${section.toLowerCase()}/${urlTitle}${dateStr}`
  ```
- Updated schema to include new fields:
  ```typescript
  schema: z.object({
    // ... existing fields ...
    notionId: z.string(),
    pageSlug: z.string(),
  })
  ```

#### NotionNavbar.vue
- Updated to use `pageSlug` for navigation links
- Added proper field selection:
  ```typescript
  .select('pageSlug', 'title', 'notionId', 'postedDate')
  ```
- Changed key to use `notionId` instead of `id`
- Simplified link generation using `pageSlug`
- Note: NavItems are ordered by date - use this to control the order in which the items appear

#### NotionPosts.vue
- Updated field selection to include new fields:
  ```typescript
  .select('pageSlug', 'title', 'description', 'postedDate', 'url', 'notionId')
  ```
- Changed post links to use `pageSlug`
- Added caching controls for development
- Added debug logging for troubleshooting

#### [...slug].vue (Catch-all Router)
- Updated route handling to use `pageSlug`:
  ```typescript
  const slug = Array.isArray(route.params.slug) 
    ? route.params.slug.join('/')
    : route.params.slug

  return queryCollection('notion')
    .where('pageSlug', '=', slug)
    .first()
  ```
- Maintained special handling for root page (first Nav item)

#### writing/[id].vue
- Updated to query by `pageSlug`:
  ```typescript
  .where('pageSlug', '=', `writing/${route.params.id}`)
  ```
- Preserved existing layout and rendering

### URL Structure Examples
```
Nav Pages:
/about-me
/contact

Writing Pages:
/writing/my-first-post-2024-03-20
/writing/another-post-2024-03-21
```

